### PR TITLE
Fixed All Flaky Tests

### DIFF
--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -198,15 +198,17 @@ public class DynamoDBEncryptorTest {
     Map<String, AttributeValue> encryptedAttributes =
         encryptor.encryptAllFieldsExcept(
             Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
-    String encryptedString = encryptedAttributes.toString();
+    HashMap<String, AttributeValue> beforeDecryption = new HashMap<>();
+    for (HashMap.Entry<String, AttributeValue> entry: encryptedAttributes.entrySet()) {
+        beforeDecryption.put(entry.getKey(), entry.getValue());
+    }
     encryptor.decryptAllFieldsExcept(
         Collections.unmodifiableMap(encryptedAttributes),
         context,
         "hashKey",
         "rangeKey",
         "version");
-
-    assertEquals(encryptedString, encryptedAttributes.toString());
+    assertTrue(beforeDecryption.equals(encryptedAttributes));
   }
 
   @Test(expectedExceptions = SignatureException.class)

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -199,16 +199,15 @@ public class DynamoDBEncryptorTest {
     Map<String, AttributeValue> encryptedAttributes =
         encryptor.encryptAllFieldsExcept(
             Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
-    String beforeDecryption = (new TreeMap<>(encryptedAttributes)).toString();
+    String encryptedString = new TreeMap<>(encryptedAttributes).toString();
     encryptor.decryptAllFieldsExcept(
         Collections.unmodifiableMap(encryptedAttributes),
         context,
         "hashKey",
         "rangeKey",
         "version");
-    String afterDecryption = (new TreeMap<>(encryptedAttributes)).toString();
 
-    assertEquals(beforeDecryption, afterDecryption);
+    assertEquals(encryptedString, new TreeMap<>(encryptedAttributes).toString());
   }
 
   @Test(expectedExceptions = SignatureException.class)

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -46,6 +46,7 @@ import java.security.SignatureException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -198,15 +199,16 @@ public class DynamoDBEncryptorTest {
     Map<String, AttributeValue> encryptedAttributes =
         encryptor.encryptAllFieldsExcept(
             Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
-    Map<String, AttributeValue> beforeDecryption = new HashMap<>(encryptedAttributes);
+    String beforeDecryption = (new TreeMap<>(encryptedAttributes)).toString();
     encryptor.decryptAllFieldsExcept(
         Collections.unmodifiableMap(encryptedAttributes),
         context,
         "hashKey",
         "rangeKey",
         "version");
+    String afterDecryption = (new TreeMap<>(encryptedAttributes)).toString();
 
-    assertEquals(beforeDecryption, encryptedAttributes);
+    assertEquals(beforeDecryption, afterDecryption);
   }
 
   @Test(expectedExceptions = SignatureException.class)

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -198,7 +198,7 @@ public class DynamoDBEncryptorTest {
     Map<String, AttributeValue> encryptedAttributes =
         encryptor.encryptAllFieldsExcept(
             Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
-    HashMap<String, AttributeValue> beforeDecryption = new HashMap<>(encryptedAttributes);
+    Map<String, AttributeValue> beforeDecryption = new HashMap<>(encryptedAttributes);
     encryptor.decryptAllFieldsExcept(
         Collections.unmodifiableMap(encryptedAttributes),
         context,

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/encryption/DynamoDBEncryptorTest.java
@@ -198,17 +198,15 @@ public class DynamoDBEncryptorTest {
     Map<String, AttributeValue> encryptedAttributes =
         encryptor.encryptAllFieldsExcept(
             Collections.unmodifiableMap(attribs), context, "hashKey", "rangeKey", "version");
-    HashMap<String, AttributeValue> beforeDecryption = new HashMap<>();
-    for (HashMap.Entry<String, AttributeValue> entry: encryptedAttributes.entrySet()) {
-        beforeDecryption.put(entry.getKey(), entry.getValue());
-    }
+    HashMap<String, AttributeValue> beforeDecryption = new HashMap<>(encryptedAttributes);
     encryptor.decryptAllFieldsExcept(
         Collections.unmodifiableMap(encryptedAttributes),
         context,
         "hashKey",
         "rangeKey",
         "version");
-    assertTrue(beforeDecryption.equals(encryptedAttributes));
+
+    assertEquals(beforeDecryption, encryptedAttributes);
   }
 
   @Test(expectedExceptions = SignatureException.class)

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -266,10 +266,18 @@ public class AttributeValueMarshallerTest {
       marshall(av);
       Assert.fail("Unexpected success");
     } catch (final NullPointerException npe) {
-      String expected_v1 = "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
-      String expected_v2 = "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
-      boolean flag = ((expected_v1.equals(npe.getMessage())) || (expected_v2.equals(npe.getMessage())));
+      // Map entries may permute under nondeterministic JAVA API
+      String npeMessage = npe.getMessage();
+      String common = "Encountered null map value for key NullKeyValue while marshalling attribute value";
+      String permutation1 = common + " {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
+      String permutation2 = common + " {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
+      boolean flag = ((permutation1.equals(npeMessage)) || (permutation2.equals(npeMessage)));
       Assert.assertTrue(flag);
+      /**
+      Assert.assertEquals(
+          "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}",
+          npe.getMessage());
+      */
     }
   }
 

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -266,9 +266,10 @@ public class AttributeValueMarshallerTest {
       marshall(av);
       Assert.fail("Unexpected success");
     } catch (final NullPointerException npe) {
-      Assert.assertEquals(
-          "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}",
-          npe.getMessage());
+      String expected_v1 = "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
+      String expected_v2 = "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
+      boolean flag = ((expected_v1.equals(npe.getMessage())) || (expected_v2.equals(npe.getMessage())));
+      Assert.assertTrue(flag);
     }
   }
 

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -273,11 +273,6 @@ public class AttributeValueMarshallerTest {
       String permutation2 = common + " {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
       boolean flag = ((permutation1.equals(npeMessage)) || (permutation2.equals(npeMessage)));
       Assert.assertTrue(flag);
-      /**
-      Assert.assertEquals(
-          "Encountered null map value for key NullKeyValue while marshalling attribute value {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}",
-          npe.getMessage());
-      */
     }
   }
 

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -266,12 +266,12 @@ public class AttributeValueMarshallerTest {
       marshall(av);
       Assert.fail("Unexpected success");
     } catch (final NullPointerException npe) {
-      // Map entries may permute under nondeterministic JAVA API
+      // Map entries may permute under nondeterministic Java API
       String npeMessage = npe.getMessage();
-      String common = "Encountered null map value for key NullKeyValue while marshalling attribute value";
-      String case1 = common + " {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
-      String case2 = common + " {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
-      Assert.assertTrue((case1.equals(npeMessage)) || (case2.equals(npeMessage)));
+      String common = "Encountered null map value for key NullKeyValue while marshalling attribute value ";
+      String case1 = common + "{M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
+      String case2 = common + "{M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
+      Assert.assertTrue(case1.equals(npeMessage) || case2.equals(npeMessage));
     }
   }
 

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -266,7 +266,7 @@ public class AttributeValueMarshallerTest {
       marshall(av);
       Assert.fail("Unexpected success");
     } catch (final NullPointerException npe) {
-      // Map entries may permute under nondeterministic JAVA API
+      // Map entries may permute under nondeterministic Java API
       String npeMessage = npe.getMessage();
       String common = "Encountered null map value for key NullKeyValue while marshalling attribute value";
       String permutation1 = common + " {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";

--- a/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
+++ b/sdk1/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/internal/AttributeValueMarshallerTest.java
@@ -266,13 +266,12 @@ public class AttributeValueMarshallerTest {
       marshall(av);
       Assert.fail("Unexpected success");
     } catch (final NullPointerException npe) {
-      // Map entries may permute under nondeterministic Java API
+      // Map entries may permute under nondeterministic JAVA API
       String npeMessage = npe.getMessage();
       String common = "Encountered null map value for key NullKeyValue while marshalling attribute value";
-      String permutation1 = common + " {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
-      String permutation2 = common + " {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
-      boolean flag = ((permutation1.equals(npeMessage)) || (permutation2.equals(npeMessage)));
-      Assert.assertTrue(flag);
+      String case1 = common + " {M: {KeyValue={S: ValueValue,}, NullKeyValue=null},}";
+      String case2 = common + " {M: {NullKeyValue=null, KeyValue={S: ValueValue,}},}";
+      Assert.assertTrue((case1.equals(npeMessage)) || (case2.equals(npeMessage)));
     }
   }
 


### PR DESCRIPTION
**Description**
2 flaky tests are found using Nondex when running commands 
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex Dtest=DynamoDBEncryptorTest#ensureEncryptedAttributesUnmodified``` 
and
```mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=AttributeValueMarshallerTest#testSimpleMapWithNull```
The reason for test flakiness is that Java map API does not preserve the order of the key-value pairs. Comparing maps by casting to string can fail when, for example, the Java version upgrades in the future, or when the code is run in different environment.

**Flaky Tests and Fixes**
- Test:`ensureEncryptedAttributesUnmodified` in `DynamoDBEncryptor.java`.
   Reason & Fix: The test tries to compare two maps after casting them to strings. However, item orders in maps are not preserved.  I converted the referenced maps to TreeMaps before casting them to string.

- Test:`testSimpleMapWithNull` in `AttributeValueMarshallerTest.java`
   Reason & Fix: Part of the expected string is a representation of a map. Similarly, order is not preserved in maps, hence I considered the 2 possible permutation patterns of the string representation of the map.